### PR TITLE
fix: changed GetProfileParams key according to Enonic docs

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -222,7 +222,7 @@ export interface ModifyUserParams {
 }
 
 export interface GetProfileParams {
-  principalKey: string;
+  key: string;
   scope?: string;
 }
 


### PR DESCRIPTION
According to Enonic documentation, `key` is used instead of `principalKey`. Using `principalKey` leads to an error.
https://repo.enonic.com/public/com/enonic/xp/docs/7.7.0/docs-7.7.0-libdoc.zip!/module-auth.html#.getProfile