### PR TITLE
Adds missing file references

### DIFF
--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -5,7 +5,10 @@
   "description": "TypeScript types for Enonic XP",
   "typings": "index.d.ts",
   "files": [
-    "index.d.ts"
+    "index.d.ts",
+    "client.d.ts,
+    "document.d.ts",
+    "model/2/constants.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
These files are missing from the npm buindle, by adding them to the files property of package.json I'm expecting them to show up in the package. 

Fixes https://github.com/ItemConsulting/enonic-types/issues/22